### PR TITLE
Allow entering explicit app name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation project(":ass")
+    implementation project(':ass')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.android.support:appcompat-v7:28.0.0"

--- a/ass/src/main/java/cz/ackee/ass/Ass.kt
+++ b/ass/src/main/java/cz/ackee/ass/Ass.kt
@@ -48,6 +48,11 @@ object Ass {
     private val detectors: MutableMap<Activity, ShakeDetector> = mutableMapOf()
 
     /**
+     * Explicitly specified app name, otherwise taken from package info.
+     */
+    private var appName: String? = null
+
+    /**
      * Map of parameters scoped to an [Activity]. Leaks should not occur because we are removing
      * references to activities when they are destroyed.
      *
@@ -173,7 +178,8 @@ object Ass {
     /**
      * Initialize the library with [url] of the server and [authToken] required by the server.
      */
-    fun initialize(app: Application, url: String, authToken: String, enableLogging: Boolean = false) {
+    fun initialize(app: Application, url: String, authToken: String, appName: String? = null, enableLogging: Boolean = false) {
+        this.appName = appName
         moshi = Moshi.Builder().build()
         apiDescription = Retrofit.Builder()
             .baseUrl(url)
@@ -270,6 +276,7 @@ object Ass {
         val screenshot = activity.window.decorView.createBitmap()
         val screenshotUri = activity.storeBitmapToCache(screenshot)
         activity.startActivity(Intent(activity, FeedbackActivity::class.java).apply {
+            putExtra(FeedbackActivity.ARG_APP_NAME, appName)
             putExtra(FeedbackActivity.ARG_FEEDBACK_DATA, FeedbackData(
                 screenshotUri,
                 HashMap(parameters + globalParameters)

--- a/ass/src/main/java/cz/ackee/ass/activity/FeedbackActivity.kt
+++ b/ass/src/main/java/cz/ackee/ass/activity/FeedbackActivity.kt
@@ -48,7 +48,15 @@ internal class FeedbackActivity : AppCompatActivity() {
     /**
      * Data received from calling activity - screenshot and user-defined custom parameters
      */
-    private val appName by lazy { intent.getStringExtra(ARG_APP_NAME) ?: null }
+    private val appName by lazy {
+        val provided = intent.getStringExtra(ARG_APP_NAME)
+        when {
+            provided.isNullOrEmpty().not() -> provided
+            else -> applicationInfo.labelRes.let { resId ->
+                if (resId == 0) applicationInfo.nonLocalizedLabel.toString() else getString(resId)
+            }
+        }
+    }
     private val feedbackData by lazy { intent.getParcelableExtra<FeedbackData>(ARG_FEEDBACK_DATA) }
     private var call: Call<Unit>? = null
     private lateinit var sendItem: MenuItem
@@ -80,12 +88,7 @@ internal class FeedbackActivity : AppCompatActivity() {
             deviceModel = Build.MODEL,
             appVersion = packageInfo.versionName,
             deviceMake = Build.MANUFACTURER,
-            appName = when {
-                !appName.isNullOrEmpty() -> appName!!
-                else -> applicationInfo.labelRes.let { resId ->
-                    if (resId == 0) applicationInfo.nonLocalizedLabel.toString() else getString(resId)
-                }
-            },
+            appName = appName,
             osVersion = "${Build.VERSION.RELEASE} (api ${Build.VERSION.SDK_INT})",
             platform = "android",
             buildNumber = @Suppress("DEPRECATION") packageInfo.versionCode,

--- a/ass/src/main/java/cz/ackee/ass/activity/FeedbackActivity.kt
+++ b/ass/src/main/java/cz/ackee/ass/activity/FeedbackActivity.kt
@@ -40,6 +40,7 @@ import java.io.File
 internal class FeedbackActivity : AppCompatActivity() {
 
     companion object {
+        const val ARG_APP_NAME = "app_name"
         const val ARG_FEEDBACK_DATA = "feedback_data"
         const val RC_SCREENSHOT_EDIT = 1
     }
@@ -47,6 +48,7 @@ internal class FeedbackActivity : AppCompatActivity() {
     /**
      * Data received from calling activity - screenshot and user-defined custom parameters
      */
+    private val appName by lazy { intent.getStringExtra(ARG_APP_NAME) ?: null }
     private val feedbackData by lazy { intent.getParcelableExtra<FeedbackData>(ARG_FEEDBACK_DATA) }
     private var call: Call<Unit>? = null
     private lateinit var sendItem: MenuItem
@@ -78,11 +80,10 @@ internal class FeedbackActivity : AppCompatActivity() {
             deviceModel = Build.MODEL,
             appVersion = packageInfo.versionName,
             deviceMake = Build.MANUFACTURER,
-            appName = applicationInfo.labelRes.let { resId ->
-                if (resId == 0) {
-                    applicationInfo.nonLocalizedLabel.toString()
-                } else {
-                    getString(resId)
+            appName = when {
+                !appName.isNullOrEmpty() -> appName!!
+                else -> applicationInfo.labelRes.let { resId ->
+                    if (resId == 0) applicationInfo.nonLocalizedLabel.toString() else getString(resId)
                 }
             },
             osVersion = "${Build.VERSION.RELEASE} (api ${Build.VERSION.SDK_INT})",


### PR DESCRIPTION
Currently appName is taken from the package info. We may want to specify app name explicitly since label from package info may contain suffixes and app version, which leads to undesired behaviour when web app displays screenshots for each version separately (App B 123 & App B 124 are treated as different projects)