### PR TITLE
📝 Prepare 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.0.0] - 2024-02-15
+### Changed
+- ‼️ Important ‼️ make the unintentionally exposed functions and extensions internal
+- Updated all dependencies (both plugins and libraries)
+- Targets API 34
+
 ## [1.2.0] - 2023-05-23
 ### Changed
 - Updated all dependencies (both plugins and libraries)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Ass.setShakeSensitivity(Ass.Sensitivity.Hard)   // makes it harder to activate
 Library can be added as a dependency from `mavenCentral` repository:
 ```
 dependencies {
-    implementation 'io.github.ackeescreenshoter:android:1.0.0'
+    implementation 'io.github.ackeescreenshoter:android:2.0.0'
 }
 ```
 

--- a/lib.properties
+++ b/lib.properties
@@ -1,6 +1,6 @@
 GROUP=io.github.ackeescreenshoter
-VERSION_NAME=1.2.0
-VERSION_CODE=10
+VERSION_NAME=2.0.0
+VERSION_CODE=11
 SITE_URL=https://github.com/AckeeScreenshoter/Android.Client
 POM_DEVELOPER_ID=ackee
 POM_DEVELOPER_NAME=Ackee


### PR DESCRIPTION
## Summary
- The major version was increased since the previous changes are breaking (making some functions internal)
- I also updated the README.md and CHANGELOG.md