### PR TITLE
🐛 Fix gradlew formatting

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -65,63 +65,43 @@
 # Attempt to set APP_HOME
 
 # Resolve links: $0 may be a link
-app_path = $0
+app_path=$0
 
 # Need this for daisy-chained symlinks.
 while
-APP_HOME = ${app_path % "${app_path##*/}"}
-#
-leaves a
-trailing /; empty if
-no leading
-path
-[ -h "$app_path" ]
+    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
+    [ -h "$app_path" ]
 do
-ls = $(ls - ld
-"$app_path" )
-link = ${ls#
-*' -> '}
-case
-$link in
-#(
-/*)   app_path=$link ;; #(
-*)    app_path=$APP_HOME$link ;;
-esac
+    ls=$( ls -ld "$app_path" )
+    link=${ls#*' -> '}
+    case $link in             #(
+      /*)   app_path=$link ;; #(
+      *)    app_path=$APP_HOME$link ;;
+    esac
 done
 
 # This is normally unused
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME = $(cd
-"${APP_HOME:-./}" > /dev/
-null &&pwd
--P ) ||
-exit
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
-        MAX_FD = maximum
+MAX_FD=maximum
 
-warn() {
-    echo
-    "$*"
-}
+warn () {
+    echo "$*"
+} >&2
 
->&2
-
-die() {
+die () {
     echo
+    echo "$*"
     echo
-    "$*"
-    echo
-    exit
-    1
-}
-
->&2
+    exit 1
+} >&2
 
 # OS specific support (must be 'true' or 'false').
-cygwin = false
+cygwin=false
 msys=false
 darwin=false
 nonstop=false
@@ -132,94 +112,58 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-        CLASSPATH = $APP_HOME / gradle / wrapper / gradle - wrapper.jar
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 
 # Determine the Java command to use to start the JVM.
-if [ -n "$JAVA_HOME" ]; then
-if [ -x "$JAVA_HOME/jre/sh/java" ];
-then
-# IBM's JDK on AIX uses strange locations for the executables
-        JAVACMD = $JAVA_HOME / jre / sh / java
-else
-JAVACMD = $JAVA_HOME / bin / java
-fi
-if [ ! -x "$JAVACMD" ];
-then
-        die
-"ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD=$JAVA_HOME/jre/sh/java
+    else
+        JAVACMD=$JAVA_HOME/bin/java
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
 
-Please set
-the JAVA_HOME
-variable in
-your environment
-to match
-the
-        location
-of your
-Java installation
-."
-fi
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
 else
-JAVACMD = java
-if ! command -
-v java
->/dev/null 2>&1
-then
-        die
-"ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    JAVACMD=java
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
-Please set
-the JAVA_HOME
-variable in
-your environment
-to match
-the
-        location
-of your
-Java installation
-."
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
 fi
-        fi
 
 # Increase the maximum file descriptors if we can.
-if ! "$cygwin" && ! "$darwin" && ! "$nonstop"; then
-case
-$MAX_FD in
-#(
-max*)
-# In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-# shellcheck disable=SC2039, SC3045
-MAX_FD = $(ulimit - H - n) ||
-         warn
-"Could not query maximum file descriptor limit"
-esac
-case
-$MAX_FD in
-#(
-'' | soft) :;; #(
-*)
-# In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-# shellcheck disable=SC2039, SC3045
-ulimit -n "$MAX_FD" ||
-warn "Could not set maximum file descriptor limit to $MAX_FD"
-esac
-        fi
+if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
+    case $MAX_FD in #(
+      max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
+        MAX_FD=$( ulimit -H -n ) ||
+            warn "Could not query maximum file descriptor limit"
+    esac
+    case $MAX_FD in  #(
+      '' | soft) :;; #(
+      *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
+        ulimit -n "$MAX_FD" ||
+            warn "Could not set maximum file descriptor limit to $MAX_FD"
+    esac
+fi
 
 # Collect all arguments for the java command, stacking in reverse order:
-#   *
-args from
-the command
-line
-#   *
-the main
-
-class name
-
+#   * args from the command line
+#   * the main class name
 #   * -classpath
-#   * -
-D...appname
-settings
+#   * -D...appname settings
 #   * --module-path (only if needed)
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, and GRADLE_OPTS environment variables.
 


### PR DESCRIPTION
## Summary
Fix the wrong formatting of the `gradlew` file that caused the script not to work. This was caused by the auto-formatting feature of the Android Studio.