### PR TITLE
Replace OkHttp Bom

### DIFF
--- a/ass/build.gradle
+++ b/ass/build.gradle
@@ -42,9 +42,10 @@ dependencies {
     implementation "com.squareup.moshi:moshi:$moshiVersion"
     ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
 
-    implementation platform('com.squareup.okhttp3:okhttp-bom:4.11.0')
-    implementation "com.squareup.okhttp3:okhttp"
-    implementation "com.squareup.okhttp3:logging-interceptor"
+    // Use versions directly without a BOM because of a problem
+    // with its resolution when used in projects
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
 
     implementation "io.coil-kt:coil:2.4.0"
 

--- a/lib.properties
+++ b/lib.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.ackeescreenshoter
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 VERSION_CODE=11
 SITE_URL=https://github.com/AckeeScreenshoter/Android.Client
 POM_DEVELOPER_ID=ackee


### PR DESCRIPTION
Due to the current gradle publish setup
the bom is attached as a regular dependency
which is not correctly resolved by applications
using this library. By using regular dependencies
the problem is solved